### PR TITLE
Make ref_alt optional as a workflow parameter

### DIFF
--- a/processing-for-variant-discovery-gatk3.wdl
+++ b/processing-for-variant-discovery-gatk3.wdl
@@ -41,7 +41,7 @@ workflow GenericPreProcessingWorkflow {
   File ref_fasta
   File ref_fasta_index
   File ref_dict
-  File ref_alt
+  File? ref_alt
   File ref_bwt
   File ref_sa
   File ref_amb


### PR DESCRIPTION
`ref_alt` is already an optional parameter to the `SamToFastqAndBwaMem` task, so it should be an optional workflow parameter as well. This makes it easier for people using hg19/GRCh37 references, who don't need this file.