### PR TITLE
Fix output_bam_basename calculation

### DIFF
--- a/processing-for-variant-discovery-gatk3.wdl
+++ b/processing-for-variant-discovery-gatk3.wdl
@@ -79,7 +79,6 @@ workflow GenericPreProcessingWorkflow {
     # Because of a wdl/cromwell bug this is not currently valid so we have to sub(sub()) in each task
     # String base_name = sub(sub(unmapped_bam, "gs://.*/", ""), unmapped_bam_suffix + "$", "")
 
-    String sub_strip_path = "gs://.*/"
     String sub_strip_unmapped = unmapped_bam_suffix + "$"
 
     # Map reads to reference
@@ -87,7 +86,7 @@ workflow GenericPreProcessingWorkflow {
       input:
         input_bam = unmapped_bam,
         bwa_commandline = bwa_commandline,
-        output_bam_basename = sub(sub(unmapped_bam, sub_strip_path, ""), sub_strip_unmapped, "") + ".unmerged",
+        output_bam_basename = sub(basename(unmapped_bam), sub_strip_unmapped, "") + ".unmerged",
         ref_fasta = ref_fasta,
         ref_fasta_index = ref_fasta_index,
         ref_dict = ref_dict,

--- a/processing-for-variant-discovery-gatk3.wdl
+++ b/processing-for-variant-discovery-gatk3.wdl
@@ -76,7 +76,6 @@ workflow GenericPreProcessingWorkflow {
   # Align flowcell-level unmapped input bams in parallel
   scatter (unmapped_bam in flowcell_unmapped_bams) {
   
-    # Because of a wdl/cromwell bug this is not currently valid so we have to sub(sub()) in each task
     String base_name = sub(basename(unmapped_bam), unmapped_bam_suffix + "$", "") + ".unmerged"
 
     # Map reads to reference

--- a/processing-for-variant-discovery-gatk3.wdl
+++ b/processing-for-variant-discovery-gatk3.wdl
@@ -41,7 +41,7 @@ workflow GenericPreProcessingWorkflow {
   File ref_fasta
   File ref_fasta_index
   File ref_dict
-  File ref_alt
+  File? ref_alt
   File ref_bwt
   File ref_sa
   File ref_amb

--- a/processing-for-variant-discovery-gatk3.wdl
+++ b/processing-for-variant-discovery-gatk3.wdl
@@ -77,16 +77,14 @@ workflow GenericPreProcessingWorkflow {
   scatter (unmapped_bam in flowcell_unmapped_bams) {
   
     # Because of a wdl/cromwell bug this is not currently valid so we have to sub(sub()) in each task
-    # String base_name = sub(sub(unmapped_bam, "gs://.*/", ""), unmapped_bam_suffix + "$", "")
-
-    String sub_strip_unmapped = unmapped_bam_suffix + "$"
+    String base_name = sub(basename(unmapped_bam), unmapped_bam_suffix + "$", "") + ".unmerged"
 
     # Map reads to reference
     call SamToFastqAndBwaMem {
       input:
         input_bam = unmapped_bam,
         bwa_commandline = bwa_commandline,
-        output_bam_basename = sub(basename(unmapped_bam), sub_strip_unmapped, "") + ".unmerged",
+        output_bam_basename = base_name,
         ref_fasta = ref_fasta,
         ref_fasta_index = ref_fasta_index,
         ref_dict = ref_dict,
@@ -107,7 +105,7 @@ workflow GenericPreProcessingWorkflow {
         bwa_commandline = bwa_commandline,
         bwa_version = GetBwaVersion.version,
         aligned_bam = SamToFastqAndBwaMem.output_bam,
-        output_bam_basename = sub(sub(unmapped_bam, sub_strip_path, ""), sub_strip_unmapped, "") + ".aligned.unsorted",
+        output_bam_basename = base_name,
         ref_fasta = ref_fasta,
         ref_fasta_index = ref_fasta_index,
         ref_dict = ref_dict,
@@ -119,7 +117,7 @@ workflow GenericPreProcessingWorkflow {
     call SortAndFixTags as SortAndFixReadGroupBam {
       input:
       input_bam = MergeBamAlignment.output_bam,
-      output_bam_basename = sub(sub(unmapped_bam, sub_strip_path, ""), sub_strip_unmapped, "") + ".sorted",
+      output_bam_basename = base_name,
       ref_dict = ref_dict,
       ref_fasta = ref_fasta,
       ref_fasta_index = ref_fasta_index,


### PR DESCRIPTION
The current implementation has a few issues:

- Code duplication (`output_bam_basename = sub(sub(unmapped_bam, sub_strip_path, ""), sub_strip_unmapped, "") + ".aligned.unsorted"` is called 3 times)
- Not portable: by stripping out only the `gs://` prefix, this workflow struggles with every other cloud URL I've tried to use it with (AWS, and DNAnexus).
- Involves casting a file to a string, with `sub(unmapped_bam, "gs://.*/", "")`. This means the file URL is converted directly to a string, and is not properly converted to the location at which this file will actually be downloaded.

I've solved these issues by using `basename()`, which is a much more portable and stable way of converting from a `File` to a `String`, and doesn't require prefix stripping. In addition I've removed the code duplication, which is no longer needed because of Cromwell fixes.

As a demonstration that this works, I've run the whole GATK3 Best Practice pipeline with my fixed version of the workflow on AWS (with Cromwell 37), and downloaded the Cromwell metadata (including the submitted workflow, and all results). Unfortunately I had to include some other AWS workarounds, but you can see from the logs that we start with this as an input:
```
    "flowcell_unmapped_bams": [
      "s3://cromwell-results/cromwell-execution/best_practise/4d3cfb17-1052-4c40-ae7c-6fa161eaf6ae/call-CPFTUB/unmap.CPFTUB/f0a79b5d-c936-40da-a427-bd657a79642e/call-PFTUB/shard
-0/NA12878_A.unmapped.bam",
      "s3://cromwell-results/cromwell-execution/best_practise/4d3cfb17-1052-4c40-ae7c-6fa161eaf6ae/call-CPFTUB/unmap.CPFTUB/f0a79b5d-c936-40da-a427-bd657a79642e/call-PFTUB/shard
-1/NA12878_B.unmapped.bam",
      "s3://cromwell-results/cromwell-execution/best_practise/4d3cfb17-1052-4c40-ae7c-6fa161eaf6ae/call-CPFTUB/unmap.CPFTUB/f0a79b5d-c936-40da-a427-bd657a79642e/call-PFTUB/shard
-2/NA12878_C.unmapped.bam"
    ]
```

And we then up with:
```
"output_bam_basename": "NA12878_A.unmapped.unmerged"
```

This is exactly what you want.

Full metadata logs are here. The workflow as a whole doesn't work (it fails for an unrelated reason), but the GenericPreProcessingWorkflow does complete successfully, which is what is of interest here.

[GenericPreProcessingWorkflow.log](https://github.com/gatk-workflows/gatk3-data-processing/files/2887351/GenericPreProcessingWorkflow.log)
[BestPractice.log](https://github.com/gatk-workflows/gatk3-data-processing/files/2887353/BestPractice.log)

